### PR TITLE
Replace generate_json() with dump() in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ And this is the output:
 
 ```python3
 test = Test()
-json = test.generate_json(file_object=open("test.json","w+"))
+json = test.dump(file_object=open("test.json","w+"), output_format="json")
 ```
 
 ### Hide certain variables


### PR DESCRIPTION
PyonObject doesn't have a method `generate_json()`, but it has a method `dump()` which will do the same if given the argument `file_object`.